### PR TITLE
Fix Entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY importer.py .
 
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-ENTRYPOINT python3 importer.py
+ENTRYPOINT ["python3", "/importer.py"]


### PR DESCRIPTION
When I run this action I get an error: `python3: can't open file 'importer.py': [Errno 2] No such file or directory`

For my (node) actions I always use an entrypoint like this:

`ENTRYPOINT ["node", "/index.js"]`